### PR TITLE
✨ Feat: Api 공통 응답 바디 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ out/
 /.nb-gradle/
 
 ## Secret property
-
-
+.env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:17
-ARG JAR_FILE=build/libs/*.jar
+ARG JAR_FILE=build/libs/cheollian-*-SNAPSHOT.jar
 COPY ${JAR_FILE} /app.jar
-ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=GMT+9", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,17 @@
 version: '3.9'
 
 services:
-  cheollian-server:
-    image: adorableco/cheollian:latest
-    restart: unless-stopped
-    container_name: cheollian-server
-    env_file:
-      - ./.env
-    environment:
-      - TZ=Asia/Seoul
-    ports:
-      - ${SPRING_PORT}:${SPRING_PORT}
-    depends_on:
-      - cheollian-database
+#  cheollian-server:
+#    image: sangming/cheollian:latest
+#    restart: unless-stopped
+#    container_name: cheollian-server
+#    env_file: .env
+#    environment:
+#      - TZ=Asia/Seoul
+#    ports:
+#      - ${SPRING_PORT}:${SPRING_PORT}
+#    depends_on:
+#      - cheollian-database
 
   cheollian-database:
     image: mysql:8.0

--- a/src/main/java/com/vision_hackathon/cheollian/util/api/ApiErrorResult.java
+++ b/src/main/java/com/vision_hackathon/cheollian/util/api/ApiErrorResult.java
@@ -1,0 +1,7 @@
+package com.vision_hackathon.cheollian.util.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiErrorResult(int status, String msg) {
+}

--- a/src/main/java/com/vision_hackathon/cheollian/util/api/ApiResponse.java
+++ b/src/main/java/com/vision_hackathon/cheollian/util/api/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.vision_hackathon.cheollian.util.api;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public final class ApiResponse {
+    public static <T> ApiSuccessResult<T> success(HttpStatus httpStatus, String msg) {
+        return new ApiSuccessResult<>(httpStatus.value(), msg, null);
+    }
+
+    public static <T> ApiSuccessResult<T> success(HttpStatus httpStatus, String msg, T response) {
+        return new ApiSuccessResult<>(httpStatus.value(), msg, response);
+    }
+
+    public static ApiErrorResult error(HttpStatus status, String msg) {
+        return new ApiErrorResult(status.value(), msg);
+    }
+}

--- a/src/main/java/com/vision_hackathon/cheollian/util/api/ApiSuccessResult.java
+++ b/src/main/java/com/vision_hackathon/cheollian/util/api/ApiSuccessResult.java
@@ -1,0 +1,7 @@
+package com.vision_hackathon.cheollian.util.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiSuccessResult<T>(int status, String msg, T data) {
+}

--- a/src/test/java/com/vision_hackathon/cheollian/util/api/ApiResponseTest.java
+++ b/src/test/java/com/vision_hackathon/cheollian/util/api/ApiResponseTest.java
@@ -1,0 +1,32 @@
+package com.vision_hackathon.cheollian.util.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class ApiResponseTest {
+
+	@Test
+	void testSuccessWithoutData() {
+		ApiSuccessResult<Void> result = ApiResponse.success(HttpStatus.OK, "Success");
+		assertEquals(HttpStatus.OK.value(), result.status());
+		assertEquals("Success", result.msg());
+		assertNull(result.data());
+	}
+
+	@Test
+	void testSuccessWithData() {
+		String data = "Test Data";
+		ApiSuccessResult<String> result = ApiResponse.success(HttpStatus.OK, "Success", data);
+		assertEquals(HttpStatus.OK.value(), result.status());
+		assertEquals("Success", result.msg());
+		assertEquals(data, result.data());
+	}
+
+	@Test
+	void testError() {
+		ApiErrorResult error = ApiResponse.error(HttpStatus.BAD_REQUEST, "Bad Request");
+		assertEquals(HttpStatus.BAD_REQUEST.value(), error.status());
+		assertEquals("Bad Request", error.msg());
+	}
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- API Response 작성
- API Response 테스트 코드 작성
- Docker 설정 로컬 개발에 맞춰 수정

---

### ✨ 참고 사항
- spring-boot-docker-compose 의존성 문제로, 도커 컴포즈와 프로젝트 빌드가 동시에 진행. 이로 인해 포트 중복 문제가 발생.
- 이를 해결하기 위해 docker-compose에서 스프링 애플리케이션 빌드 부분을 주석 처리.
- 배포 환경에서는 주석을 풀어야하기에 어떻게 구성할지 생각해야 할 듯 합니다.

---

### ⏰ 현재 버그
- x 

---

### ✏ Git Close
- #5  
