### PR TITLE
 Feat: 회원가입

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - ${SPRING_PORT}:${SPRING_PORT}
     depends_on:
       - cheollian-database
+    networks:
+      - cheollian-network
+
 
   cheollian-database:
     image: mysql:8.0
@@ -35,7 +38,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
+    networks:
+      - cheollian-network
+      -
   cheollian-redis:
     image: redis:5.0
     container_name: cheollian-redis
@@ -48,6 +53,13 @@ services:
       - cheollian-redis:/data
     restart: always
 
+    networks:
+      - cheollian-network
+
 volumes:
   cheollian-database:
   cheollian-redis:
+
+networks:
+  cheollian-network:
+    external: true

--- a/src/main/java/com/vision_hackathon/cheollian/member/controller/MemberController.java
+++ b/src/main/java/com/vision_hackathon/cheollian/member/controller/MemberController.java
@@ -1,11 +1,11 @@
 package com.vision_hackathon.cheollian.member.controller;
 
+import com.vision_hackathon.cheollian.member.dto.SignUpRequestDto;
+import com.vision_hackathon.cheollian.member.dto.SignUpResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.vision_hackathon.cheollian.auth.security.LoggedInUser;
 import com.vision_hackathon.cheollian.auth.security.details.PrincipalDetails;
@@ -34,5 +34,15 @@ public class MemberController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ApiResponse.success(HttpStatus.OK, responseBody));
+	}
+
+	@PostMapping("sign-up")
+	@PreAuthorize("hasRole('USER') and isAuthenticated()")
+	public ResponseEntity<ApiSuccessResult<SignUpResponseDto>> signUp(
+			@RequestBody SignUpRequestDto request,
+			@LoggedInUser PrincipalDetails principalDetails
+	){
+		return ResponseEntity
+				.ok(ApiResponse.success(HttpStatus.OK, memberService.signUp(request, principalDetails.member())));
 	}
 }

--- a/src/main/java/com/vision_hackathon/cheollian/member/dto/SignUpRequestDto.java
+++ b/src/main/java/com/vision_hackathon/cheollian/member/dto/SignUpRequestDto.java
@@ -1,0 +1,23 @@
+package com.vision_hackathon.cheollian.member.dto;
+
+import com.vision_hackathon.cheollian.member.entity.Gender;
+import lombok.Getter;
+
+@Getter
+public class SignUpRequestDto {
+    private String nickname;
+
+    private String profileImage;
+
+    private float height;
+
+    private float weight;
+
+    private int age;
+
+    private Gender gender;
+
+    private String schoolName;
+
+    private int schoolCode;
+}

--- a/src/main/java/com/vision_hackathon/cheollian/member/dto/SignUpResponseDto.java
+++ b/src/main/java/com/vision_hackathon/cheollian/member/dto/SignUpResponseDto.java
@@ -1,0 +1,17 @@
+package com.vision_hackathon.cheollian.member.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class SignUpResponseDto {
+    private UUID memberId;
+
+    @Builder
+    public SignUpResponseDto(UUID memberId) {
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/vision_hackathon/cheollian/member/entity/Member.java
+++ b/src/main/java/com/vision_hackathon/cheollian/member/entity/Member.java
@@ -81,4 +81,10 @@ public class Member extends BaseAuditEntity {
 		this.role = role;
 		this.memberDetail = memberDetail;
 	}
+
+	public void connectMemberDetail(MemberDetail memberDetail) {
+		this.memberDetail = memberDetail;
+	}
+
+
 }

--- a/src/main/java/com/vision_hackathon/cheollian/member/service/MemberService.java
+++ b/src/main/java/com/vision_hackathon/cheollian/member/service/MemberService.java
@@ -1,5 +1,10 @@
 package com.vision_hackathon.cheollian.member.service;
 
+import com.vision_hackathon.cheollian.member.dto.SignUpRequestDto;
+import com.vision_hackathon.cheollian.member.dto.SignUpResponseDto;
+import com.vision_hackathon.cheollian.member.entity.Member;
+import com.vision_hackathon.cheollian.member.entity.MemberDetail;
+import com.vision_hackathon.cheollian.member.persistence.MemberDetailRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,4 +17,27 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MemberService {
 	private final MemberRepository memberRepository;
+    private final MemberDetailRepository memberDetailRepository;
+
+    @Transactional
+    public SignUpResponseDto signUp(SignUpRequestDto request, Member member) {
+
+        MemberDetail memberDetail = MemberDetail.builder()
+                .memberId(member.getMemberId())
+                .member(member)
+                .age(request.getAge())
+                .gender(request.getGender())
+                .height(request.getHeight())
+                .weight(request.getWeight())
+                .nickname(request.getNickname())
+                .profileImage(request.getProfileImage())
+                .schoolCode(request.getSchoolCode())
+                .schoolName(request.getSchoolName())
+                .build();
+
+        member.connectMemberDetail(memberDetail);
+        memberRepository.save(member);
+
+        return new SignUpResponseDto(member.getMemberId());
+    }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 회원가입 기능을 구현했습니다.

---

### ✨ 참고 사항
- 구글 로그인 시도 후 `hasMemberDetails` 존재 여부를 확인하여 회원가입 플로우로 들어가게 되므로 `accessToken`을 가지고 있다고 판단하고, 인증이 된 경우에 회원가입을 진행할 수 있도록 구현했습니다.
- `profileImage`는  일단 요청 시에 url을 포함하도록 했는데 클라이언트에서 구글 계정 이미지 url를 포함해주는 식으로 흘러가야할 것 같습니다.

---

### ⏰ 현재 버그

x

---

### ✏ Git Close

- #29 
